### PR TITLE
Use labelColor to get automatic system support for light / dark mode

### DIFF
--- a/Quests/Helper/NSColor+ThemeColors.swift
+++ b/Quests/Helper/NSColor+ThemeColors.swift
@@ -25,24 +25,9 @@
 import Cocoa
 
 extension NSColor {
-    static var isDarkMode: Bool {
-        if #available(macOS 11, *) {
-            let item = NSStatusBar.system.statusItem(withLength: 1)
-            if let name = item.button?.effectiveAppearance.name.rawValue.lowercased() {
-                return name.contains("dark")
-            }
-        } else {
-            let mode = UserDefaults.standard.string(forKey: "AppleInterfaceStyle")
-            return mode == "Dark"
-        }
-
-        return false
-    }
-
     struct ThemeColor {
         static var text: NSColor {
-            let mode = UserDefaults.standard.string(forKey: "AppleInterfaceStyle")
-            return mode == "Dark" ? NSColor.white : NSColor.black
+            return NSColor.labelColor
         }
         static var highlightedText: NSColor {
             NSColor.white


### PR DESCRIPTION
Fixes #12.

# What It Does

* Uses the built-in `labelColor` for the menu bar item labels.
* Removes custom `isDarkMode` check which is no longer used.

## How I Tested

Followed the steps in #12.