### PR TITLE
Fixes #14 - Cached all repo names. Found a different way to show all.

### DIFF
--- a/Quests/WindowController/SettingsWindowController.swift
+++ b/Quests/WindowController/SettingsWindowController.swift
@@ -70,9 +70,12 @@ class SettingsWindowController: NSWindowController, NSWindowDelegate {
 
             let totalHeight = itemSize.height + largeHeaderSize.height + headerSize.height * CGFloat(repos.count - 1) + itemSize.height * CGFloat(repos.flatMap { $0.repos }.count)
             repoCollectionView?.snp.updateConstraints { make in make.height.equalTo(totalHeight) }
+
+            allRepoNames = repos.flatMap { owner in owner.repos.map { $0.name } }
         }
     }
     private var repoCollectionItems = [String: RepoCheckCollectionViewItem]()
+    private var allRepoNames = [String]()
 
     private let itemSize = CGSize(width: 220, height: 20)
     private let largeHeaderSize = CGSize(width: 220, height: 37)
@@ -407,10 +410,13 @@ extension SettingsWindowController: NSCollectionViewDataSource, NSCollectionView
 
 extension SettingsWindowController: RepoCheckCollectionViewItemDelegate {
     func repoCheckCollectionViewItem(_ repoCheckCollectionViewItem: RepoCheckCollectionViewItem, didToggleShowAll: Bool) {
-        for item in repoCollectionItems {
-            item.value.checkButton.state = didToggleShowAll ? .on : .off
-            item.value.buttonChecked(item.value.checkButton)
+        if didToggleShowAll {
+            Defaults[.ignoredRepos].removeAll()
+        } else {
+            Defaults[.ignoredRepos] = allRepoNames
         }
+
+        repoCollectionView?.reloadData()
     }
 }
 


### PR DESCRIPTION
### Linked Issue: #14

## Screen recording of suggested fix

https://user-images.githubusercontent.com/9044401/153538479-59574347-9a65-4c58-b5c9-d3a72cf04bd5.mp4

## Behind the black box
You'll notice that when I select the top button, they all toggle and scrolling through all 557 shows that they're toggling correctly and quickly.
